### PR TITLE
chore: update pages workflow to v4 actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,12 +21,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-        contents: read
-        pages: write
-        id-token: write
+      contents: read
+      pages: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies
@@ -43,9 +43,9 @@ jobs:
           TWITTER_HANDLE: ${{ env.TWITTER_HANDLE }}
           DEFAULT_OG_IMAGE: ${{ env.DEFAULT_OG_IMAGE }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR updates the GitHub Pages workflow to use the v4 versions of actions/checkout, setup-node, upload-pages-artifact, and deploy-pages for compatibility with the new artifact upload actions and to resolve deprecation issues. This should allow manual Pages builds to succeed.